### PR TITLE
Fix Python 3.5 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: python
 python:
   - "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: python
+cache: pip
+
 python:
   - "3.5"
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
 
 install:
   - pip install -U pip
-  - python setup.py install
   - pip install tox-travis
 
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - "3.8"
 
 install:
+  - pip install -U pip
   - python setup.py install
   - pip install tox-travis
 


### PR DESCRIPTION
Updates PR https://github.com/django-macaddress/django-macaddress/pull/39.

That PR was failing because some dependency of `python setup.py install` installs a new version of zipp that doesn't support Python 3.5.

And there's no need to run `python setup.py install` when testing via tox, it's done for you inside the virtualenv.

---

Also update the version of pip for good measure, cache pip, and `sudo: false` no longer has any effect (see https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).